### PR TITLE
Dependabot: add cooldown, reduce interval to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,7 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
-      day: monday
+      interval: monthly
     open-pull-requests-limit: 10
     groups:
       astro:
@@ -24,10 +23,16 @@ updates:
           - "tailwindcss"
           - "@tailwindcss/*"
           - "postcss"
+    cooldown:
+      # https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns
+      # Cooldowns protect against supply chain attacks by avoiding the
+      # highest-risk window immediately after new releases.
+      default-days: 14
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
-      day: monday
+      interval: monthly
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 14


### PR DESCRIPTION
cooldown:

Similar to https://github.com/python/cpython/pull/141866, see https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns

interval:

Reduce notification fatigue.
