### PR TITLE
Add components for cves, gh issues, and python downloadss

### DIFF
--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -1437,6 +1437,84 @@ body {
   border-color: rgba(160, 160, 170, 0.32);
 }
 
+/* ── GitHub issue/PR — Green ────────────────────────── */
+
+.prose .ref-gh-issue {
+  color: #1a6d2e;
+  background-color: rgba(34, 140, 60, 0.08);
+  border-color: rgba(34, 140, 60, 0.2);
+}
+
+.prose .ref-gh-issue:hover {
+  color: #145524;
+  background-color: rgba(34, 140, 60, 0.14);
+  border-color: rgba(34, 140, 60, 0.35);
+}
+
+.dark .prose .ref-gh-issue {
+  color: #6ddb8a;
+  background-color: rgba(50, 180, 80, 0.12);
+  border-color: rgba(50, 180, 80, 0.25);
+}
+
+.dark .prose .ref-gh-issue:hover {
+  color: #8de8a4;
+  background-color: rgba(50, 180, 80, 0.2);
+  border-color: rgba(50, 180, 80, 0.4);
+}
+
+/* ── CVE — Red/rose ────────────────────────────────── */
+
+.prose .ref-cve {
+  color: #9f1239;
+  background-color: rgba(190, 30, 70, 0.07);
+  border-color: rgba(190, 30, 70, 0.18);
+}
+
+.prose .ref-cve:hover {
+  color: #7f0f2e;
+  background-color: rgba(190, 30, 70, 0.13);
+  border-color: rgba(190, 30, 70, 0.32);
+}
+
+.dark .prose .ref-cve {
+  color: #f0758e;
+  background-color: rgba(220, 60, 90, 0.12);
+  border-color: rgba(220, 60, 90, 0.25);
+}
+
+.dark .prose .ref-cve:hover {
+  color: #f5a0b2;
+  background-color: rgba(220, 60, 90, 0.2);
+  border-color: rgba(220, 60, 90, 0.4);
+}
+
+/* ── Python release — Python blue (distinct) ────────── */
+
+.prose .ref-py-release {
+  color: #1a5276;
+  background-color: rgba(30, 100, 160, 0.08);
+  border-color: rgba(30, 100, 160, 0.2);
+}
+
+.prose .ref-py-release:hover {
+  color: #144060;
+  background-color: rgba(30, 100, 160, 0.14);
+  border-color: rgba(30, 100, 160, 0.35);
+}
+
+.dark .prose .ref-py-release {
+  color: #68b5e8;
+  background-color: rgba(50, 130, 200, 0.12);
+  border-color: rgba(50, 130, 200, 0.25);
+}
+
+.dark .prose .ref-py-release:hover {
+  color: #90caf0;
+  background-color: rgba(50, 130, 200, 0.2);
+  border-color: rgba(50, 130, 200, 0.4);
+}
+
 /* ── Post footer references panel ── */
 
 .post-refs-header {

--- a/src/components/references/_icons.ts
+++ b/src/components/references/_icons.ts
@@ -33,6 +33,27 @@ export const docsIcon = lucide(
   '<path d="M12 7v14"/><path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"/>',
 );
 
+/** Lucide `circle-dot` — GitHub issue/PR */
+export const issueIcon = lucide(
+  14,
+  14,
+  '<circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="1"/>',
+);
+
+/** Lucide `shield-alert` — CVE / security vulnerability */
+export const shieldIcon = lucide(
+  14,
+  14,
+  '<path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/><path d="M12 8v4"/><path d="M12 16h.01"/>',
+);
+
+/** Lucide `download` — Python release download */
+export const downloadIcon = lucide(
+  14,
+  14,
+  '<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/>',
+);
+
 /** Lucide `arrow-up-right` — external link indicator */
 export const externalIcon = lucide(
   11,

--- a/src/plugins/remark-python-refs.ts
+++ b/src/plugins/remark-python-refs.ts
@@ -8,8 +8,11 @@
  *   - PEP links  (by URL pattern OR link text matching "PEP NNN")
  *   - CPython docs (docs.python.org/...)
  *   - PyPI links (pypi.org/project/NAME/)
+ *   - GitHub issues/PRs (github.com/OWNER/REPO/issues|pull/NNN)
  *   - GitHub repos (github.com/OWNER/REPO — exactly 2 path segments)
  *   - GitHub users/orgs (github.com/NAME — exactly 1 segment, not reserved)
+ *   - CVE references (nvd.nist.gov/vuln/detail/CVE-YYYY-NNNNN)
+ *   - Python releases (python.org/downloads/release/python-XXXX/)
  */
 import type { Root, Link, Paragraph, PhrasingContent } from "mdast";
 import { visit } from "unist-util-visit";
@@ -18,6 +21,9 @@ import {
   docsIcon,
   githubIcon,
   packageIcon,
+  issueIcon,
+  shieldIcon,
+  downloadIcon,
   externalIcon,
 } from "../components/references/_icons.js";
 
@@ -27,6 +33,9 @@ const PEP_OLD = /^https?:\/\/(?:www\.)?python\.org\/dev\/peps\/pep-(\d+)\/?/i;
 const PEP_NEW = /^https?:\/\/peps\.python\.org\/pep-(\d+)\/?/i;
 const DOCS = /^https?:\/\/docs\.python\.org\//i;
 const PYPI = /^https?:\/\/pypi\.org\/project\/([^/]+)\/?/i;
+const GH_ISSUE = /^https?:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(issues|pull)\/(\d+)\/?/i;
+const CVE = /^https?:\/\/nvd\.nist\.gov\/vuln\/detail\/(CVE-[\d-]+)\/?/i;
+const PY_RELEASE = /^https?:\/\/(?:www\.)?python\.org\/downloads\/release\/(python-[\w.]+)\/?/i;
 const GITHUB =
   /^https?:\/\/github\.com\/([\w.-]+)(?:\/([\w.-]+))?\/?$/i;
 
@@ -64,7 +73,7 @@ const GH_RESERVED = new Set([
 
 // ── Helpers ─────────────────────────────────────────────
 
-type RefType = "pep" | "docs" | "pypi" | "gh-repo" | "gh-user";
+type RefType = "pep" | "docs" | "pypi" | "gh-repo" | "gh-user" | "gh-issue" | "cve" | "py-release";
 
 interface Match {
   type: RefType;
@@ -106,6 +115,18 @@ function classify(url: string, linkText?: string): Omit<Match, "label" | "url"> 
 
   if ((m = url.match(PYPI))) {
     return { type: "pypi", icon: packageIcon };
+  }
+
+  if ((m = url.match(GH_ISSUE))) {
+    return { type: "gh-issue", icon: issueIcon };
+  }
+
+  if ((m = url.match(CVE))) {
+    return { type: "cve", icon: shieldIcon };
+  }
+
+  if ((m = url.match(PY_RELEASE))) {
+    return { type: "py-release", icon: downloadIcon };
   }
 
   if ((m = url.match(GITHUB))) {


### PR DESCRIPTION
Adds 3 new components to go with our existing:
- CVE
- GitHub Issue (we already have GH profile, gh rpeo)
- Python releases 

<img width="802" height="328" alt="image" src="https://github.com/user-attachments/assets/1b461b58-92ce-4d3e-abcc-aaab0d5fe36b" />
<img width="742" height="257" alt="image" src="https://github.com/user-attachments/assets/06d20710-4ce7-4f1b-b86b-9367745eaeee" />
