### PR TITLE
Use `dc:creator` instead of email-less `author`

### DIFF
--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -16,12 +16,13 @@ export async function GET(context: APIContext) {
     title: "Python Insider",
     description: "The official blog of the Python core development team.",
     site: context.site!.toString(),
+    xmlns: { dc: "http://purl.org/dc/elements/1.1/" },
     items: posts.map((post) => ({
       title: post.data.title,
       pubDate: post.data.publishDate,
       description: post.data.description ?? "",
       link: withBase(`${postUrl(post.id, post.data.publishDate)}/`),
-      author: post.data.author,
+      customData: `<dc:creator>${post.data.author}</dc:creator>`,
       categories: post.data.tags,
     })),
   });


### PR DESCRIPTION
Fixes https://github.com/python/python-insider-blog/issues/29.

`<author>` is meant to include an email address.

Instead, we can use `<dc:creator>`:

> The value of the `dc:creator` element is less restrictive than the [author](https://www.rssboard.org/rss-profile#element-channel-item-author) element, which must contain an e-mail address. Publishers often rely on `dc:creator` to credit authorship without revealing e-mail addresses in a form that can be exploited by spammers.

https://www.rssboard.org/rss-profile#namespace-elements-dublin-creator