### PR TITLE
Wrap and shorten long URLs

### DIFF
--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -1495,6 +1495,8 @@ body {
   color: #1a5276;
   background-color: rgba(30, 100, 160, 0.08);
   border-color: rgba(30, 100, 160, 0.2);
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 .prose .ref-py-release:hover {

--- a/src/plugins/remark-python-refs.ts
+++ b/src/plugins/remark-python-refs.ts
@@ -284,9 +284,16 @@ export default function remarkPythonRefs() {
     visit(tree, "link", (node: Link, index, parent) => {
       if (index == null || !parent) return;
 
-      const label = extractText(node.children);
-      const info = classify(node.url, label);
+      const rawLabel = extractText(node.children);
+      const info = classify(node.url, rawLabel);
       if (!info) return;
+
+      // For autolinked bare URLs, drop the protocol, leading "www.",
+      // and trailing slash so the badge reads "python.org/downloads/..."
+      // rather than the full "https://www.python.org/.../" form.
+      const label = rawLabel.startsWith("http")
+        ? rawLabel.replace(/^https?:\/\/(?:www\.)?/i, "").replace(/\/$/, "")
+        : rawLabel;
 
       collectRef(info.type, label, node.url);
       const html = buildBadgeHtml({ ...info, label, url: node.url });


### PR DESCRIPTION

Plain URLs such as https://www.python.org/downloads/release/python-3150b1/ on pages like https://blog.python.org/2026/05/python-3150-beta-1/ don't wrap, meaning there's some annoying horizontal scroll on mobile.

It's also an accessibility issue: https://www.w3.org/WAI/WCAG21/Techniques/css/C33

We can also strip out any leading `https://` or `http://`, and `www.`, to make them a bit shorter.


<table>
<tr>
<th>Before
<th>After
<tr>
<td><img width="219" height="447" alt="image" src="https://github.com/user-attachments/assets/e836bec5-257d-4f00-9f81-2215882d8b7d" />
<td><img width="218" height="447" alt="image" src="https://github.com/user-attachments/assets/581ca0da-3710-43d7-8eb2-f919f3466a4b" />
</table>

