### PR TITLE
Remove Home menu on mobile

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -25,6 +25,7 @@ const currentPath = Astro.url.pathname;
           href={href}
           class:list={[
             "rounded-lg px-3.5 py-2 text-sm font-medium transition-all duration-200",
+            label === "Home" && "hidden sm:inline-flex",
             currentPath === href || (href !== "/" && currentPath.startsWith(href))
               ? "bg-[#306998]/10 text-[#306998] dark:bg-[#ffd43b]/10 dark:text-[#ffd43b]"
               : "text-zinc-700 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-300 dark:hover:bg-zinc-800 dark:hover:text-zinc-100",


### PR DESCRIPTION
Even with https://github.com/python/python-insider-blog/pull/78, the top menu bar also causes horizontal scrolling.

We can remove the "Home" link for mobile, because the logo and "Python Insider" text also link there.

<table>
<tr>
<th>Before
<th>Before
<th>After
<tr>
<td>
<img width="218" height="441" alt="image" src="https://github.com/user-attachments/assets/071363ac-5aaa-49e6-8b64-82862159c70b" />
<td>
<img width="220" height="448" alt="image" src="https://github.com/user-attachments/assets/38ba634c-8c2d-48be-9155-ea8eede6eb17" />
<td>
<img width="219" height="448" alt="image" src="https://github.com/user-attachments/assets/f41eee3a-6157-423d-b59f-0cacd6386f16" />
</table>





