### PR TITLE
Allow wrapping any badge

### DIFF
--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -1281,7 +1281,7 @@ body {
   text-decoration: none;
   border: 1px solid;
   transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
   vertical-align: baseline;
 }
 
@@ -1495,8 +1495,6 @@ body {
   color: #1a5276;
   background-color: rgba(30, 100, 160, 0.08);
   border-color: rgba(30, 100, 160, 0.2);
-  overflow-wrap: anywhere;
-  white-space: normal;
 }
 
 .prose .ref-py-release:hover {


### PR DESCRIPTION

Follow on from https://github.com/python/python-insider-blog/pull/78.

It's not just URL badges that don't wrap on mobile, it's all the badges.

Let's generalise the fix and apply it to all badges:

<table>
<tr>
<th>Before
<th>After
<tr>
<td>
<img width="200" height="408" alt="image" src="https://github.com/user-attachments/assets/759b761c-9b21-47d4-a54e-9c59fd16f692" />
<img width="204" height="412" alt="image" src="https://github.com/user-attachments/assets/2211e3c9-97fd-4714-bef1-4f9f8bbf2d31" />
<td>
<img width="205" height="413" alt="image" src="https://github.com/user-attachments/assets/7317b913-cf87-4cae-b798-2264b34f6a16" />
</table>

https://blog.python.org/2026/05/python-3145-is-out/