### PR TITLE
New blog post: 2026 Packaging Council election dates

### DIFF
--- a/content/authors/pradyun-gedam.json
+++ b/content/authors/pradyun-gedam.json
@@ -1,0 +1,10 @@
+{
+  "name": "Pradyun Gedam",
+  "bio": "Python packaging maintainer and pip developer",
+  "github": "pradyunsg",
+  "avatar": "",
+  "bluesky": "https://bsky.app/profile/pradyunsg.me",
+  "mastodon": "https://mastodon.social/@pradyunsg",
+  "website": "https://pradyunsg.me",
+  "featured": false
+}

--- a/content/posts/2026-packaging-council-election-dates/index.md
+++ b/content/posts/2026-packaging-council-election-dates/index.md
@@ -1,0 +1,70 @@
+---
+title: Packaging Council Inaugural Election Dates
+publishDate: "2026-06-28"
+author: Pradyun Gedam
+description: "A new Python Packaging Council (PPC) is being established, with their election of the inaugural PPC will be held in parallel to the 2026 PSF Board election."
+published: true
+---
+
+With the recent approval of [PEP 772 – Packaging Council governance process](https://peps.python.org/pep-0772/), a new Python Packaging Council (PPC) is being established with broad authority over packaging specifications and the mandate to coordinate Python packaging efforts. The election of the inaugural PPC will be held in parallel to the 2026 Python Software Foundation (PSF) Board election.
+
+## What is the Packaging Council?
+
+The PPC will be the technical decision making body for the [interoperability specifications](https://packaging.python.org/en/latest/specifications/) affecting how Python packages are built, distributed, and installed.
+
+The council will also serve as a coordinating body for the Python packaging ecosystem, working with many stakeholders from the wider Python community toward an ever-improving packaging user experience. This will include the maintainers of various packaging tools like the Python Packaging Authority (PyPA), the Python core team, the Python Steering Council, and the PSF.
+
+## Election Overview
+
+The 2026 inaugural election fills all five seats on the PPC. The two candidates receiving the highest number of votes shall be designated Cohort A with a two year term, and the three candidates receiving the next highest number of votes shall be designated Cohort B with a one year term.
+
+In future elections, each cohort will be elected for a full two-year term in alternating years, so that roughly half of the PPC turns over each cycle.
+
+## Election Timeline
+
+The PPC election follows the same timeline as the PSF Board election:
+
+- Nominations open: Tuesday, July 28th, 2:00 pm UTC
+- Nomination cut-off: Tuesday, August 11th, 2:00 pm UTC
+- Announce candidates: Thursday, August 13th
+- Voter affirmation cut-off: Tuesday, August 25th, 2:00 pm UTC
+- Voting start date: Tuesday, September 1st, 2:00 pm UTC
+- Voting end date: Tuesday, September 15th, 2:00 pm UTC
+
+### Voting
+
+You must be a Contributing, Supporting, or Fellow member by August 25th **and** affirm your intention to vote to participate in this election.
+
+Check out the [PSF membership](https://www.python.org/psf/membership/) page to learn more about membership classes and benefits. You can affirm your voting intention by following the steps in [the PSF’s video tutorial](https://www.youtube.com/watch?v=lWfyvPqAAJs):
+
+- Log in to [psfmember.org](http://psfmember.org)
+- Choose “Your Memberships” page at the top right to check your eligibility to vote (You must be a Contributing, Supporting, or Fellow member)
+- Choose “Voting Affirmation” page at the top right
+- Select your preferred intention for voting in 2026 (which now includes a second affirmation regarding your intention to vote in the PPC election)
+- Click the “Submit” button
+
+Like the PSF Board elections, casting a vote in a PPC election will automatically affirm your intention to participate in the next PPC election.
+
+If you have questions about membership, please email [pc-elections@python.org](mailto:pc-elections@python.org).
+
+### Election communications from [psfmember.org](http://psfmember.org)
+
+PSF Members should review their communication preferences on [psfmember.org](http://psfmember.org) if you would like to opt in or out of receiving emails about the PSF Board, PPC elections, or both. Here’s how:
+
+- Login to [psfmember.org](http://psfmember.org)
+- Navigate to your [“Profile” page](https://psfmember.org/profile/)
+- Click the “Name and Address” tab
+- Scroll down, designate your preferences
+- Click submit
+
+If you had previously opted out of communications from the PSF through [psfmember.org](http://psfmember.org) and would like to review or change your preference, we encourage you to update them using the instructions above. The PSF only sends a handful of election and fundraising related communications every year via [psfmember.org](http://psfmember.org).
+
+## Running for the Packaging Council
+
+Do you have a vision for improving the Python packaging experience? Do you make the tools used to build and consume Python packages? Are you passionate about building communities, consensus, and standards focused on the user experience? If these resonate with you, and you have the time to attend regular meetings and participate in the standardization process, you should consider running for the inaugural PPC\!
+
+We're looking for candidates who can build bridges between projects and communities, who enjoy working with a very large community of passionate volunteers, and have a willingness to represent the wider community ahead of any single tool, project, or employer. We also welcome candidates who have a diverse set of skills and experiences, including open-governance experience, community stewardship, fundraising knowledge, and (of course\!) technical expertise in Python packaging and distribution.
+
+PEP 772 does provide [non-binding operational suggestions](https://peps.python.org/pep-0772/#appendix-b-operational-suggestions-for-the-council), which hint at how the council could function. As this is the inaugural PPC, the individuals serving on it will be establishing the initial operating procedures, scope, interests, and agenda that future councils will build upon. Notably, "[establishing specific processes for \[the\] Packaging Council and PyPA relationship](https://peps.python.org/pep-0772/#establishing-specific-processes-for-packaging-council-and-pypa-relationship)" is something that the inaugural Packaging Council is expected to do.
+
+You can nominate yourself or someone else. If you're nominating someone else, we'd encourage you to reach out to them first to make sure they're excited about the opportunity and give them a heads up that they'll need to submit their own nomination statement too. Nominations open on Tuesday, July 28th, 2:00 pm UTC, so you have time to talk with potential nominees, research the role, and craft a nomination statement for yourself or others. Remember, **nominees must themselves be PSF voting members, and nomination statements must include information about the nominee’s relevant affiliations.**

--- a/content/posts/2026-packaging-council-election-dates/index.md
+++ b/content/posts/2026-packaging-council-election-dates/index.md
@@ -16,7 +16,7 @@ The council will also serve as a coordinating body for the Python packaging ecos
 
 ## Election Overview
 
-The 2026 inaugural election fills all five seats on the PPC. The two candidates receiving the highest number of votes shall be designated Cohort A with a two year term, and the three candidates receiving the next highest number of votes shall be designated Cohort B with a one year term.
+The 2026 inaugural election fills all five seats on the PPC. The two candidates receiving the highest number of votes shall be designated Cohort A with a two-year term, and the three candidates receiving the next highest number of votes shall be designated Cohort B with a one-year term.
 
 In future elections, each cohort will be elected for a full two-year term in alternating years, so that roughly half of the PPC turns over each cycle.
 
@@ -37,8 +37,8 @@ You must be a Contributing, Supporting, or Fellow member by August 25th **and** 
 
 Check out the [PSF membership](https://www.python.org/psf/membership/) page to learn more about membership classes and benefits. You can affirm your voting intention by following the steps in [the PSF’s video tutorial](https://www.youtube.com/watch?v=lWfyvPqAAJs):
 
-- Log in to [psfmember.org](http://psfmember.org)
-- Choose “Your Memberships” page at the top right to check your eligibility to vote (You must be a Contributing, Supporting, or Fellow member)
+- Log in to [psfmember.org](https://psfmember.org/)
+- Choose “Your Memberships” page at the top right to check your eligibility to vote (you must be a Contributing, Supporting, or Fellow member)
 - Choose “Voting Affirmation” page at the top right
 - Select your preferred intention for voting in 2026 (which now includes a second affirmation regarding your intention to vote in the PPC election)
 - Click the “Submit” button
@@ -47,17 +47,17 @@ Like the PSF Board elections, casting a vote in a PPC election will automaticall
 
 If you have questions about membership, please email [pc-elections@python.org](mailto:pc-elections@python.org).
 
-### Election communications from [psfmember.org](http://psfmember.org)
+### Election communications from [psfmember.org](https://psfmember.org)
 
-PSF Members should review their communication preferences on [psfmember.org](http://psfmember.org) if you would like to opt in or out of receiving emails about the PSF Board, PPC elections, or both. Here’s how:
+PSF Members should review their communication preferences on [psfmember.org](https://psfmember.org) if you would like to opt in or out of receiving emails about the PSF Board, PPC elections, or both. Here’s how:
 
-- Login to [psfmember.org](http://psfmember.org)
+- Log in to [psfmember.org](https://psfmember.org)
 - Navigate to your [“Profile” page](https://psfmember.org/profile/)
 - Click the “Name and Address” tab
 - Scroll down, designate your preferences
 - Click submit
 
-If you had previously opted out of communications from the PSF through [psfmember.org](http://psfmember.org) and would like to review or change your preference, we encourage you to update them using the instructions above. The PSF only sends a handful of election and fundraising related communications every year via [psfmember.org](http://psfmember.org).
+If you had previously opted out of communications from the PSF through [psfmember.org](https://psfmember.org) and would like to review or change your preference, we encourage you to update them using the instructions above. The PSF only sends a handful of election and fundraising related communications every year via [psfmember.org](https://psfmember.org).
 
 ## Running for the Packaging Council
 


### PR DESCRIPTION
This particular series of posts will also be cross-posted on the PSF blog.