### PR TITLE
Fix empty book icon

### DIFF
--- a/src/plugins/remark-python-refs.ts
+++ b/src/plugins/remark-python-refs.ts
@@ -85,7 +85,7 @@ interface Match {
 function extractText(children: PhrasingContent[]): string {
   return children
     .map((c) => {
-      if (c.type === "text") return c.value;
+      if (c.type === "text" || c.type === "inlineCode") return c.value;
       if ("children" in c) return extractText(c.children as PhrasingContent[]);
       return "";
     })


### PR DESCRIPTION
Those book icons aren't too useful:

<img width="788" height="381" alt="image" src="https://github.com/user-attachments/assets/fca3e55e-a3a9-4942-bd3d-356303385122" />

Fix:

<img width="786" height="491" alt="image" src="https://github.com/user-attachments/assets/cd410085-8226-4feb-bc42-c5fed40e6764" />

